### PR TITLE
fix(http): serialize shared CredentialCache mutation (fixes Calibre scan crash)

### DIFF
--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -80,10 +80,20 @@ namespace NzbDrone.Common.Http.Dispatchers
                 else if (request.Credentials is NetworkCredential nc)
                 {
                     var creds = GetCredentialCache();
-                    foreach (var authtype in new[] { "Basic", "Digest" })
+
+                    // CredentialCache (System.Net) is not thread-safe and this
+                    // dispatcher's cache is a shared singleton. Concurrent
+                    // requests to the same URL — e.g. the Calibre root-folder
+                    // health check overlapping a library rescan — can both pass
+                    // Remove() and then race on Add(), throwing "An item with the
+                    // same key has already been added." Serialize the mutation.
+                    lock (creds)
                     {
-                        creds.Remove((Uri)request.Url, authtype);
-                        creds.Add((Uri)request.Url, authtype, nc);
+                        foreach (var authtype in new[] { "Basic", "Digest" })
+                        {
+                            creds.Remove((Uri)request.Url, authtype);
+                            creds.Add((Uri)request.Url, authtype, nc);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

With a **Calibre library root folder**, disk scans crash intermittently and the library shows as empty. Log:

```
[Error] CalibreRootFolderCheck: Unknown error occured in CalibreRootFolderCheck HealthCheck
System.ArgumentException: An item with the same key has already been added. Key: [....]:http://<calibre>/ajax/books/<lib>?ids=...:Basic
   at System.Net.CredentialCache.Add(Uri uriPrefix, String authType, NetworkCredential cred)
   at NzbDrone.Core.Books.Calibre.CalibreProxy.GetAllBookFilePaths(CalibreSettings settings)
   at NzbDrone.Core.MediaFiles.DiskScanService.GetBookFiles(String path, Boolean allDirectories)
[Warn] DiskScanService: Scan folder /books is empty.
```

## Root cause

`ManagedHttpDispatcher` caches a single shared `CredentialCache` instance. For `NetworkCredential` requests it does `Remove()` + `Add()` per auth type on that shared instance. `System.Net.CredentialCache` is **not thread-safe**, so two concurrent requests to the same URL can both pass `Remove()` (nothing to remove) and then race on `Add()`, and the second `Add()` throws *"An item with the same key has already been added."*

This reproduces reliably with Calibre because two code paths call `CalibreProxy.GetAllBookFilePaths()` against the **same** Calibre URL at the same time:
- the periodic `CalibreRootFolderCheck` health check, and
- a `RescanFolders` disk scan.

## Fix

Wrap the `Remove`/`Add` mutation in a `lock` on the shared cache instance. Minimal and targeted — serialization only, no behavioural change.

## Testing

Built the `distribution/docker/Dockerfile` image with this patch and deployed against a live Calibre library (~33k books). Before: every scan that overlapped the health check threw the exception above (0 books enumerated). After: repeated concurrent `RescanFolders` triggers — 0 occurrences of "same key has already been added"; the Calibre scan completes.