### PR TITLE
fix(import): stop NREs on candidates that never went through the database

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
@@ -375,6 +375,37 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
             {
                 // We have to make sure various bits and pieces are populated that are normally handled
                 // by a database lazy load
+                //
+                // Author/AuthorMetadata/SeriesLinks are part of that set. A metadata
+                // source can leave them unset — the ISBN/ASIN edition lookup builds a
+                // slim book with no author at all, and the work and search mappers omit
+                // the author when the source returns no name or key. Downstream
+                // identification (DistanceCalculator, LocalEdition.PopulateMatch)
+                // dereferences them, so a null here fails the whole import run rather
+                // than just skipping the candidate.
+                if (book.AuthorMetadata?.Value == null)
+                {
+                    book.AuthorMetadata = new AuthorMetadata { Name = string.Empty };
+                }
+                else if (book.AuthorMetadata.Value.Name == null)
+                {
+                    book.AuthorMetadata.Value.Name = string.Empty;
+                }
+
+                if (book.Author?.Value == null)
+                {
+                    book.Author = new Author { Metadata = book.AuthorMetadata.Value, CleanName = string.Empty };
+                }
+                else if (book.Author.Value.Metadata?.Value == null)
+                {
+                    book.Author.Value.Metadata = book.AuthorMetadata.Value;
+                }
+
+                if (book.SeriesLinks == null)
+                {
+                    book.SeriesLinks = new List<SeriesBookLink>();
+                }
+
                 foreach (var edition in book.Editions.Value)
                 {
                     edition.Book = book;

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/DistanceCalculator.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/DistanceCalculator.cs
@@ -39,8 +39,12 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
 
             var authors = GetAuthorVariants(fileAuthors);
 
-            dist.AddString("author", authors, edition.Book.Value.AuthorMetadata.Value.Name);
-            Logger.Trace("author: '{0}' vs '{1}'; {2}", authors.ConcatToString("' or '"), edition.Book.Value.AuthorMetadata.Value.Name, dist.NormalizedDistance());
+            // A candidate mapped straight from a metadata source has not been
+            // through a DB lazy-load, so Book/AuthorMetadata can be unpopulated.
+            var editionAuthorName = edition.Book?.Value?.AuthorMetadata?.Value?.Name ?? string.Empty;
+
+            dist.AddString("author", authors, editionAuthorName);
+            Logger.Trace("author: '{0}' vs '{1}'; {2}", authors.ConcatToString("' or '"), editionAuthorName, dist.NormalizedDistance());
 
             var title = localTracks.MostCommon(x => x.FileTrackInfo.BookTitle) ?? "";
             var titleOptions = new List<string> { edition.Title };
@@ -49,7 +53,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 titleOptions.Add(StripSeriesRegex.Replace(titleOptions[0]));
             }
 
-            var (maintitle, _) = edition.Title.SplitBookTitle(edition.Book.Value.AuthorMetadata.Value.Name);
+            var (maintitle, _) = edition.Title.SplitBookTitle(editionAuthorName);
             if (!titleOptions.Contains(maintitle))
             {
                 titleOptions.Add(maintitle);

--- a/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryWorkMapper.cs
+++ b/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryWorkMapper.cs
@@ -87,6 +87,19 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
                 .Select(k => new AuthorMetadata { ForeignAuthorId = ExtractKey(k), TitleSlug = ExtractKey(k) })
                 .ToList();
 
+            // Attach the primary author to the book itself. Callers that hand a
+            // freshly-mapped book to import identification (rather than adding it
+            // to the DB first) get no lazy-load, so Book.Author and
+            // Book.AuthorMetadata would stay null and dereference downstream.
+            // ForeignAuthorId is enough to match on; the display name is filled in
+            // by the per-author /authors/{key}.json refresh.
+            var primaryAuthor = authors.FirstOrDefault();
+            if (primaryAuthor != null)
+            {
+                book.AuthorMetadata = primaryAuthor;
+                book.Author = new Author { Metadata = primaryAuthor, CleanName = string.Empty };
+            }
+
             return (book, authors);
         }
 

--- a/src/NzbDrone.Core/Parser/Model/LocalEdition.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEdition.cs
@@ -54,6 +54,7 @@ namespace NzbDrone.Core.Parser.Model
                     var book = new Book();
                     book.UseMetadataFrom(fullBook);
                     book.UseDbFieldsFrom(fullBook);
+
                     // A candidate that never went through the DB has no Author to
                     // lazy-load, so both the new book's Author and the matched
                     // book's Author/AuthorMetadata may be null here.

--- a/src/NzbDrone.Core/Parser/Model/LocalEdition.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEdition.cs
@@ -54,16 +54,35 @@ namespace NzbDrone.Core.Parser.Model
                     var book = new Book();
                     book.UseMetadataFrom(fullBook);
                     book.UseDbFieldsFrom(fullBook);
-                    book.Author.Value.UseMetadataFrom(fullBook.Author.Value);
-                    book.Author.Value.UseDbFieldsFrom(fullBook.Author.Value);
-                    book.Author.Value.Metadata = fullBook.AuthorMetadata.Value;
-                    book.AuthorMetadata = fullBook.AuthorMetadata.Value;
+                    // A candidate that never went through the DB has no Author to
+                    // lazy-load, so both the new book's Author and the matched
+                    // book's Author/AuthorMetadata may be null here.
+                    var fullAuthor = fullBook.Author?.Value;
+                    var fullAuthorMeta = fullBook.AuthorMetadata?.Value ?? new AuthorMetadata { Name = string.Empty };
+
+                    if (book.Author?.Value == null)
+                    {
+                        book.Author = new Author();
+                    }
+
+                    if (fullAuthor != null)
+                    {
+                        book.Author.Value.UseMetadataFrom(fullAuthor);
+                        book.Author.Value.UseDbFieldsFrom(fullAuthor);
+                    }
+
+                    book.Author.Value.Metadata = fullAuthorMeta;
+                    book.AuthorMetadata = fullAuthorMeta;
                     book.BookFiles = fullBook.BookFiles;
                     book.Editions = new List<Edition> { edition };
 
-                    if (fullBook.SeriesLinks.IsLoaded)
+                    // Remote candidates arrive with SeriesLinks unset, which NREs
+                    // on the .IsLoaded check. Treat null as "no series".
+                    if (fullBook.SeriesLinks != null && fullBook.SeriesLinks.IsLoaded)
                     {
-                        book.SeriesLinks = fullBook.SeriesLinks.Value.Select(l => new SeriesBookLink
+                        book.SeriesLinks = fullBook.SeriesLinks.Value
+                            .Where(l => l.Series?.Value != null)
+                            .Select(l => new SeriesBookLink
                         {
                             Book = book,
                             Series = new Series


### PR DESCRIPTION
## Problem

A library import aborts with a `NullReferenceException` partway through, taking
the whole run with it rather than skipping the one book it could not handle.

## Root cause

Import identification assumes every `Book` it receives has been through a
database lazy-load, and dereferences unconditionally:

- `DistanceCalculator` — `edition.Book.Value.AuthorMetadata.Value.Name`
- `LocalEdition.PopulateMatch` — `fullBook.Author.Value`,
  `fullBook.AuthorMetadata.Value`, `fullBook.SeriesLinks.IsLoaded`

Candidates mapped straight from a metadata source have not been through that
load. Three ways they arrive incomplete:

1. the ISBN/ASIN edition lookup builds a slim `Book` with no author at all;
2. `OpenLibraryWorkMapper` returns authors as a separate list and never
   attaches one to the book;
3. `SeriesLinks` is left null on remote candidates, which NREs on the
   `.IsLoaded` check before the existing `?.Value?.Any()` guards can help.

`CandidateService.ToCandidates` already documents itself as the place where
this is handled — *"We have to make sure various bits and pieces are populated
that are normally handled by a database lazy load"* — but it only populates
`edition.Book`.

## Fix

Four changes, all on that path:

| File | Change |
|---|---|
| `CandidateService.ToCandidates` | backfill `Author` / `AuthorMetadata` / `SeriesLinks` stubs, extending what the method already does |
| `OpenLibraryWorkMapper` | attach the primary author to the book it returns, so the common path needs no stub |
| `DistanceCalculator` | read the author name null-safely, reuse it for the title split |
| `LocalEdition.PopulateMatch` | guard the `Author` clone, treat null `SeriesLinks` as "no series", skip links whose `Series` did not resolve |

No behavioural change for fully-populated candidates: every guard falls through
to the existing code when the value is present.

## Testing

Running in a personal build against a ~33k-book Calibre library since
2026-07-23. Before the change the import crashed on the first book whose
candidate came from a metadata source rather than the database; after it the
run completes and unmatched candidates are simply not selected.

I have not added a unit test — happy to, but `LocalEdition.PopulateMatch` needs
a fair amount of scaffolding to exercise directly, so I would rather follow your
preference on where that belongs.
