### PR TITLE
fix(import): catch the exceptions the OpenLibrary path actually throws

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/CandidateService.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.Exceptions;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
 using NzbDrone.Core.Books;
 using NzbDrone.Core.MetadataSource;
-using NzbDrone.Core.MetadataSource.Goodreads;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.BookImport.Identification
@@ -213,9 +215,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 {
                     remoteBooks = _bookSearchService.SearchByIsbn(isbns[0]);
                 }
-                catch (GoodreadsException e)
+                catch (Exception e) when (e is NzbDroneException or HttpException)
                 {
-                    _logger.Info(e, "Skipping ISBN search due to Goodreads Error");
+                    _logger.Info(e, "Skipping ISBN search due to metadata source error");
                     remoteBooks = new List<Book>();
                 }
 
@@ -235,9 +237,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 {
                     remoteBooks = _bookSearchService.SearchByAsin(asins[0]);
                 }
-                catch (GoodreadsException e)
+                catch (Exception e) when (e is NzbDroneException or HttpException)
                 {
-                    _logger.Info(e, "Skipping ASIN search due to Goodreads Error");
+                    _logger.Info(e, "Skipping ASIN search due to metadata source error");
                     remoteBooks = new List<Book>();
                 }
 
@@ -258,9 +260,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                     {
                         remoteBooks = _bookSearchService.SearchByForeignBookId(goodreads[0], true);
                     }
-                    catch (GoodreadsException e)
+                    catch (Exception e) when (e is NzbDroneException or HttpException)
                     {
-                        _logger.Info(e, "Skipping Goodreads ID search due to Goodreads Error");
+                        _logger.Info(e, "Skipping Goodreads ID search due to metadata source error");
                         remoteBooks = new List<Book>();
                     }
 
@@ -313,9 +315,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 {
                     remoteBooks = _bookSearchService.SearchForNewBook(bookTag, authorTag);
                 }
-                catch (GoodreadsException e)
+                catch (Exception e) when (e is NzbDroneException or HttpException)
                 {
-                    _logger.Info(e, "Skipping author/title search due to Goodreads Error");
+                    _logger.Info(e, "Skipping author/title search due to metadata source error");
                     remoteBooks = new List<Book>();
                 }
 
@@ -336,9 +338,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
             {
                 remoteBooks = _bookSearchService.SearchForNewBook(bookTag, null);
             }
-            catch (GoodreadsException e)
+            catch (Exception e) when (e is NzbDroneException or HttpException)
             {
-                _logger.Info(e, "Skipping book title search due to Goodreads Error");
+                _logger.Info(e, "Skipping book title search due to metadata source error");
                 remoteBooks = new List<Book>();
             }
 
@@ -354,9 +356,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
                 {
                     remoteBooks = _bookSearchService.SearchForNewBook(a, null);
                 }
-                catch (GoodreadsException e)
+                catch (Exception e) when (e is NzbDroneException or HttpException)
                 {
-                    _logger.Info(e, "Skipping author search due to Goodreads Error");
+                    _logger.Info(e, "Skipping author search due to metadata source error");
                     remoteBooks = new List<Book>();
                 }
 


### PR DESCRIPTION
## Problem

A single 404 from OpenLibrary — one edition that no longer resolves — aborts
the entire import run. The code reads as though it tolerates this: every
metadata lookup in `CandidateService` sits in a `try`/`catch` that logs
"Skipping … search" and continues with an empty result.

Those handlers never fire.

## Root cause

All six catch blocks are `catch (GoodreadsException)`, and that type is
unreachable from the OpenLibrary metadata source:

```
ApplicationException
└── NzbDroneException
    ├── OpenLibraryException          ← thrown by OpenLibraryProxy
    └── NzbDroneClientException
        └── GoodreadsException        ← what the handlers catch

Exception
└── HttpException                     ← thrown on a 404
```

`OpenLibraryException` is a *sibling* of `GoodreadsException`, not a subtype,
so it escapes. And HTTP failures never enter that hierarchy at all:

- `OpenLibraryProxy` sets `SuppressHttpError = false`, so HTTP errors throw.
- `Send<T>`'s retry only swallows retryable responses, and `IsRetryable` covers
  `TooManyRequests` and `HasHttpServerError` only.

A 404 is neither, so it propagates out of `Send<T>` as an `HttpException`,
reaches `CandidateService`, matches no handler, and unwinds the import.

This is a leftover from the Goodreads-to-OpenLibrary migration — the handlers
were correct when Goodreads was the only metadata source.

## Fix

Catch `NzbDroneException` (covering both `OpenLibraryException` and
`GoodreadsException`) and `HttpException`, using an exception filter so each
site keeps its single existing handler:

```csharp
catch (Exception e) when (e is NzbDroneException or HttpException)
```

Deliberately **not** a blanket `catch (Exception)`: a null-reference or mapping
bug should still surface rather than be quietly logged as a skipped search.

Log messages reworded from "Goodreads Error" to "metadata source error", since
Goodreads is no longer the only source reaching this code. The now-unused
`NzbDrone.Core.MetadataSource.Goodreads` using is dropped.

## Testing

**Note on provenance, since it differs from the other two PRs in this set.**
My own build has been running a broader `catch (System.Exception)` at these six
sites since 2026-07-23, which is what proved the handlers were not firing —
with it, imports survive OpenLibrary hiccups; without it, one 404 kills the run.
The narrow filter in this PR is a deliberate tightening of that, so the *effect*
is production-tested but this exact predicate is not. The hierarchy and the
`IsRetryable` reasoning above are read from the current `main`, not assumed.

If you would rather see it proven first, I am happy to run this exact build
against the same library and report back before you merge.
