### PR TITLE
Declare the Error log the breaker tests provoke

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/MetadataSourceStatusServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/MetadataSourceStatusServiceFixture.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.MetadataSource.Events;
 using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MetadataSource
 {
@@ -63,6 +64,8 @@ namespace NzbDrone.Core.Test.MetadataSource
 
             GivenFailures(1, status);
             Subject.IsAvailable.Should().BeFalse();
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
@@ -74,6 +77,8 @@ namespace NzbDrone.Core.Test.MetadataSource
             }
 
             Subject.IsAvailable.Should().BeFalse("a DNS failure is the clearest possible refusal");
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
@@ -87,6 +92,8 @@ namespace NzbDrone.Core.Test.MetadataSource
 
             Subject.RecordFailure(new IOException("stream torn"));
             Subject.IsAvailable.Should().BeFalse();
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
@@ -105,6 +112,8 @@ namespace NzbDrone.Core.Test.MetadataSource
             GivenFailures(5, HttpStatusCode.TooManyRequests);
 
             Assert.Throws<MetadataSourceUnavailableException>(() => Subject.EnsureAvailable());
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
@@ -131,6 +140,9 @@ namespace NzbDrone.Core.Test.MetadataSource
                 Subject.Now = Subject.UnavailableUntil.Value;
                 Subject.IsAvailable.Should().BeTrue("the window has expired, so we probe again");
             }
+
+            // One Error per trip; tripping is meant to be loud.
+            ExceptionVerification.ExpectedErrors(expected.Length);
         }
 
         [Test]
@@ -147,6 +159,8 @@ namespace NzbDrone.Core.Test.MetadataSource
             // Escalation reset too: the next outage starts at the shortest window.
             GivenFailures(5, HttpStatusCode.TooManyRequests);
             (Subject.UnavailableUntil.Value - Subject.Now).TotalMinutes.Should().BeApproximately(5.0, 0.01);
+
+            ExceptionVerification.ExpectedErrors(2);
         }
 
         [Test]
@@ -155,6 +169,8 @@ namespace NzbDrone.Core.Test.MetadataSource
             GivenFailures(5, HttpStatusCode.TooManyRequests);
 
             VerifyEventPublished<MetadataSourceUnavailableEvent>();
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
@@ -167,6 +183,8 @@ namespace NzbDrone.Core.Test.MetadataSource
             GivenFailures(3, HttpStatusCode.TooManyRequests);
 
             Subject.UnavailableUntil.Should().Be(first, "the window must not keep sliding out");
+
+            ExceptionVerification.ExpectedErrors(1);
         }
     }
 


### PR DESCRIPTION
Eleven tests in `MetadataSourceStatusServiceFixture` — every one that trips the breaker — violated `ExceptionVerification.AssertNoUnexpectedLogs()` in teardown. The service logs at `Error` when it trips, deliberately, and the fixture never said so.

They passed anyway, for two independent reasons:

- **Locally:** `OutputPath` in `Directory.Build.props` ignores `$(Configuration)` — Debug and Release both write to `_output/` and `_tests/`. Building `Readarr.Core.csproj` with `-c Release` to check StyleCop left Release assemblies in place, so `BuildInfo.IsDebug` was false on every later `dotnet test` and `LoggingTest`'s teardown skipped the assertion.
- **In CI:** `build.sh:131` publishes with `-p:Configuration=Release` and the unit-test job runs those artifacts, so `BuildInfo.IsDebug` is false there too. `AssertNoUnexpectedLogs` has never run in CI.

Surfaced by building the whole solution in Debug, which restored `IsDebug` and failed all eleven at once.

The fix declares the expected `Error` count per test, which also pins that tripping is loud — the entire point of the feature.

The second bullet is the more interesting half and is filed separately as #12; this PR only fixes the tests.

## Verification

Full Debug battery, all green:

| Suite | Result |
|---|---|
| Common | 624 passed |
| Core | 2826 passed |
| Api / Host / Libraries / Update / Mono | 93 passed |
| Frontend vitest | 25 passed |
| eslint / stylelint | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)