### PR TITLE
fix(openlibrary): derive the ISBN-13 an isbn_10-only edition actually carries

### DIFF
--- a/src/NzbDrone.Core.Test/BookTests/IsbnUtilsFixture.cs
+++ b/src/NzbDrone.Core.Test/BookTests/IsbnUtilsFixture.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.BookTests
+{
+    [TestFixture]
+    public class IsbnUtilsFixture : TestBase
+    {
+        [TestCase("0441172717", "9780441172719")]
+        [TestCase("0062316095", "9780062316097")]
+        [TestCase("043942089X", "9780439420891")] // X check digit = 10, dropped in conversion
+        [TestCase("0-441-17271-7", "9780441172719")] // hyphens tolerated
+        public void Isbn10ToIsbn13_converts_valid_isbn10(string isbn10, string expected)
+        {
+            IsbnUtils.Isbn10ToIsbn13(isbn10).Should().Be(expected);
+        }
+
+        [TestCase("0441172661")] // fails its own ISBN-10 checksum
+        [TestCase("not-an-isbn")]
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("9780441172719")] // already 13 digits, not an ISBN-10
+        public void Isbn10ToIsbn13_returns_null_for_anything_that_is_not_a_valid_isbn10(string input)
+        {
+            IsbnUtils.Isbn10ToIsbn13(input).Should().BeNull();
+        }
+
+        [TestCase("0441172717", "9780441172719")] // 10 -> 13
+        [TestCase("9780441172719", "9780441172719")] // 13 passes through
+        [TestCase("978-0-441-17271-9", "9780441172719")] // normalised then passed through
+        public void ToIsbn13_puts_both_forms_into_isbn13_space(string input, string expected)
+        {
+            IsbnUtils.ToIsbn13(input).Should().Be(expected);
+        }
+
+        [TestCase("0441172661")] // invalid ISBN-10 checksum -> not convertible
+        [TestCase("12345")] // neither length
+        [TestCase(null)]
+        public void ToIsbn13_returns_null_for_unconvertible_input(string input)
+        {
+            IsbnUtils.ToIsbn13(input).Should().BeNull();
+        }
+
+        [TestCase("0441172717", true)]
+        [TestCase("043942089X", true)]
+        [TestCase("0441172661", false)]
+        [TestCase("044117271", false)] // nine digits
+        public void IsValidIsbn10_checks_the_checksum(string isbn, bool expected)
+        {
+            IsbnUtils.IsValidIsbn10(isbn).Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Identification/DistanceCalculatorFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/TrackImport/Identification/DistanceCalculatorFixture.cs
@@ -139,6 +139,119 @@ namespace NzbDrone.Core.Test.MediaFiles.BookImport.Identification
             Score(string.Empty).Should().BeApproximately(0.1875, 0.0001);
         }
 
+        // #13 review, Finding 1. StripIsbn keeps a valid ISBN-10 file tag at
+        // ten digits, while an edition's Isbn13 is thirteen (listed, or derived
+        // from an isbn_10-only record per #10). A raw string compare reads that
+        // as a full 10.0-weight mismatch against the very edition the file was
+        // looked up by — worse than the 0.1 isbn_missing it used to fall into.
+        // Both sides are converted to ISBN-13 before comparison, so the ten-
+        // digit tag is not penalised for its format.
+        [Test]
+        public void isbn10_file_tag_should_match_the_editions_isbn13()
+        {
+            double Score(string fileIsbn)
+            {
+                var edition = new Edition
+                {
+                    Title = "Dune",
+                    Isbn13 = "9780441172719",
+                    Book = new Book
+                    {
+                        Title = "Dune",
+                        AuthorMetadata = new AuthorMetadata { Name = "Frank Herbert" }
+                    }
+                };
+
+                var localBooks = new List<LocalBook>
+                {
+                    new LocalBook
+                    {
+                        Path = "/books/dune.epub",
+                        FileTrackInfo = new ParsedTrackInfo
+                        {
+                            Authors = new List<string> { "Frank Herbert" },
+                            BookTitle = "Dune",
+                            Isbn = fileIsbn
+                        }
+                    }
+                };
+
+                return DistanceCalculator.BookDistance(localBooks, edition).NormalizedDistance();
+            }
+
+            // 0441172717 is the ISBN-10 form of 9780441172719: same edition,
+            // so a perfect match, and identical to the ISBN-13-tagged form.
+            Score("0441172717").Should().Be(0.0);
+            Score("0441172717").Should().Be(Score("9780441172719"));
+
+            // A genuinely different ISBN (0441172660 -> 9780441172665) is still
+            // a real mismatch and must not be laundered into a match.
+            Score("0441172660").Should().BeGreaterThan(0.0);
+
+            // Not every file tag arrives through StripIsbn. AggregateCalibreData
+            // assigns FileTrackInfo.Isbn straight from Calibre's identifiers
+            // dictionary with no validation or normalisation at all, so a
+            // hyphenated identifier reaches here verbatim — and under the raw
+            // compare it never matched anything, whatever its format. That is a
+            // defect older than the ISBN-13 derivation, and NormalizeIsbn fixes
+            // it as a side effect: both ISBN forms match with hyphens in place.
+            Score("978-0-441-17271-9").Should().Be(0.0);
+            Score("0-441-17271-7").Should().Be(0.0);
+        }
+
+        // The same unvalidated Calibre path can also deliver a value that is
+        // neither a valid ISBN-10 nor thirteen digits. ToIsbn13 maps it to null,
+        // which moves it out of the 10.0-weight isbn bucket and into the 0.1
+        // isbn_missing one — it used to compare unequal and take the full
+        // penalty. Pinning the shift rather than blessing it: a value that
+        // cannot be put in ISBN-13 space is not evidence of a *different* book,
+        // so the lighter bucket is the defensible reading, but it is a change
+        // in behaviour that the review describing this fix did not mention.
+        [Test]
+        public void unconvertible_file_tag_should_score_as_missing_rather_than_mismatched()
+        {
+            double Score(string fileIsbn)
+            {
+                var edition = new Edition
+                {
+                    Title = "Dune",
+                    Isbn13 = "9780441172719",
+                    Book = new Book
+                    {
+                        Title = "Dune",
+                        AuthorMetadata = new AuthorMetadata { Name = "Frank Herbert" }
+                    }
+                };
+
+                var localBooks = new List<LocalBook>
+                {
+                    new LocalBook
+                    {
+                        Path = "/books/dune.epub",
+                        FileTrackInfo = new ParsedTrackInfo
+                        {
+                            Authors = new List<string> { "Frank Herbert" },
+                            BookTitle = "Dune",
+                            Isbn = fileIsbn
+                        }
+                    }
+                };
+
+                return DistanceCalculator.BookDistance(localBooks, edition).NormalizedDistance();
+            }
+
+            // "0441172661" fails its own ISBN-10 checksum; twelve digits is
+            // neither length. Both now score as the edition having an ISBN the
+            // file does not, which is what an absent tag scores.
+            var missing = Score(null);
+
+            Score("0441172661").Should().Be(missing);
+            Score("978044117271").Should().Be(missing);
+
+            // And that is strictly lighter than a real mismatch.
+            missing.Should().BeLessThan(Score("0441172660"));
+        }
+
         // A candidate mapped straight from a metadata source has not been
         // through a DB lazy load, so Book.AuthorMetadata can be null. Scoring
         // one must not take the whole import run down.

--- a/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryEditionMapperFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryEditionMapperFixture.cs
@@ -68,12 +68,31 @@ namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
         }
 
         [Test]
-        public void ToEdition_should_fall_back_to_the_first_valid_isbn10_without_a_queried_isbn()
+        public void ToEdition_should_leave_isbn13_null_for_several_isbn10_without_a_queried_isbn()
         {
+            // #13 review, Finding 2. On the work-list mapping path there is no
+            // queried ISBN to pick a printing by. Committing to the first would
+            // fabricate a *different* edition's ISBN-13 (0441172660 derives to
+            // 9780441172665, not the 9780441172719 a file might carry), which
+            // then scores the full 10.0-weight mismatch — worse than the 0.1
+            // isbn_missing that null yields. With nothing to disambiguate,
+            // stay null rather than guess.
             var edition = OpenLibraryEditionMapper.ToEdition(Resource(
                 isbn10: new List<string> { "0441172660", "0441172717" }));
 
-            edition.Isbn13.Should().Be("9780441172665");
+            edition.Isbn13.Should().BeNull();
+        }
+
+        [Test]
+        public void ToEdition_should_still_derive_a_lone_isbn10_without_a_queried_isbn()
+        {
+            // The single-printing case (Sapiens) is unambiguous, so the
+            // work-list path still derives it — only several-with-no-query
+            // stays null.
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "0062316095" }));
+
+            edition.Isbn13.Should().Be("9780062316097");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryEditionMapperFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryEditionMapperFixture.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MetadataSource.OpenLibrary.Mappers;
+using NzbDrone.Core.MetadataSource.OpenLibrary.Resources;
+
+namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
+{
+    // ISBN selection in OpenLibraryEditionMapper (issue #10). Two of the five
+    // captured /isbn/ payloads — Dune and Sapiens — carry no `isbn_13` at all:
+    // OL answered with `isbn_10` only, in both cases the checksum-equivalent of
+    // the ISBN-13 that was queried. Reading `isbn_13` alone sent those
+    // candidates to the matcher with no ISBN, dropping the 10.0-weight isbn
+    // bucket from DistanceCalculator's denominator (0.2857 vs the 0.20 gate,
+    // measured in PR #4).
+    //
+    // Deriving ISBN-13 from ISBN-10 is a checksum, not a round trip: prefix
+    // 978, drop the ISBN-10 check digit, recompute mod-10. The one subtlety is
+    // *which* entry: Dune's record lists two ISBN-10s for the same edition
+    // record (different printings), and only the second is the ISBN that was
+    // queried. Blindly taking the first would fabricate a *different* ISBN-13
+    // than the one the caller looked up — worse than none, because a present
+    // and mismatched ISBN scores the full 10.0-weight bucket at distance 1.
+    // So the queried ISBN, when the caller knows it, wins over list order.
+    [TestFixture]
+    public class OpenLibraryEditionMapperFixture
+    {
+        [Test]
+        public void ToEdition_should_use_isbn13_when_present()
+        {
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn13: new List<string> { "9780553293357" },
+                isbn10: new List<string> { "0553293354" }));
+
+            edition.Isbn13.Should().Be("9780553293357");
+        }
+
+        [Test]
+        public void ToEdition_should_prefer_the_queried_isbn13_over_list_order()
+        {
+            var edition = OpenLibraryEditionMapper.ToEdition(
+                Resource(isbn13: new List<string> { "9780441172665", "9780441172719" }),
+                "9780441172719");
+
+            edition.Isbn13.Should().Be("9780441172719");
+        }
+
+        [Test]
+        public void ToEdition_should_derive_isbn13_from_a_lone_isbn10()
+        {
+            // Sapiens, as OL actually served it: isbn_10 only.
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "0062316095" }));
+
+            edition.Isbn13.Should().Be("9780062316097");
+        }
+
+        [Test]
+        public void ToEdition_should_derive_the_queried_isbn13_when_isbn10_lists_several()
+        {
+            // Dune, as OL actually served it: two printings on one edition
+            // record, and the queried ISBN is the *second*.
+            var edition = OpenLibraryEditionMapper.ToEdition(
+                Resource(isbn10: new List<string> { "0441172660", "0441172717" }),
+                "9780441172719");
+
+            edition.Isbn13.Should().Be("9780441172719");
+        }
+
+        [Test]
+        public void ToEdition_should_fall_back_to_the_first_valid_isbn10_without_a_queried_isbn()
+        {
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "0441172660", "0441172717" }));
+
+            edition.Isbn13.Should().Be("9780441172665");
+        }
+
+        [Test]
+        public void ToEdition_should_accept_the_queried_isbn_in_isbn10_form()
+        {
+            // ReidentifyService passes whatever the file's tags carry, and
+            // older or Calibre-tagged files commonly hold an ISBN-10. The
+            // query is compared in ISBN-13 space, so the second printing
+            // still wins over list order.
+            var edition = OpenLibraryEditionMapper.ToEdition(
+                Resource(isbn10: new List<string> { "0441172660", "0441172717" }),
+                "0441172717");
+
+            edition.Isbn13.Should().Be("9780441172719");
+        }
+
+        [Test]
+        public void ToEdition_should_match_an_isbn10_query_against_listed_isbn13_entries()
+        {
+            var edition = OpenLibraryEditionMapper.ToEdition(
+                Resource(isbn13: new List<string> { "9780441172665", "9780441172719" }),
+                "0441172717");
+
+            edition.Isbn13.Should().Be("9780441172719");
+        }
+
+        [Test]
+        public void ToEdition_should_convert_an_x_check_digit_isbn10()
+        {
+            // X = 10 in the ISBN-10 checksum; the digit is dropped in
+            // conversion, so the derived ISBN-13 is all-numeric.
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "043942089X" }));
+
+            edition.Isbn13.Should().Be("9780439420891");
+        }
+
+        [Test]
+        public void ToEdition_should_skip_isbn10_entries_that_fail_their_own_checksum()
+        {
+            // A corrupt entry must not be laundered into a plausible-looking
+            // ISBN-13 — deriving validates before it converts.
+            var edition = OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "0441172661", "0062316095" }));
+
+            edition.Isbn13.Should().Be("9780062316097");
+        }
+
+        [Test]
+        public void ToEdition_should_leave_isbn13_null_when_no_usable_isbn_exists()
+        {
+            OpenLibraryEditionMapper.ToEdition(Resource())
+                .Isbn13.Should().BeNull();
+
+            OpenLibraryEditionMapper.ToEdition(Resource(
+                isbn10: new List<string> { "not-an-isbn", "0441172661" }))
+                .Isbn13.Should().BeNull();
+        }
+
+        [Test]
+        public void ToBook_should_thread_the_queried_isbn_to_the_edition()
+        {
+            var book = OpenLibraryEditionMapper.ToBook(
+                Resource(isbn10: new List<string> { "0441172660", "0441172717" }),
+                "9780441172719");
+
+            book.Editions.Value.Should().ContainSingle()
+                .Which.Isbn13.Should().Be("9780441172719");
+        }
+
+        private static OpenLibraryEditionResource Resource(List<string> isbn13 = null, List<string> isbn10 = null)
+        {
+            return new OpenLibraryEditionResource
+            {
+                Key = "/books/OL22597282M",
+                Title = "Dune",
+                Isbn13 = isbn13,
+                Isbn10 = isbn10
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryIsbnSearchCassetteFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryIsbnSearchCassetteFixture.cs
@@ -25,30 +25,29 @@ namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
     //      work-level docs and whichever ISBN happens to be listed first).
     //      See the review on PR #4.
     //
-    //      The *ISBN* does not always survive with it, which is the more
-    //      interesting half. ToEdition reads `isbn_13` only, and two of the five
-    //      captures — Dune and Sapiens — carry no `isbn_13` at all: OL answered
-    //      with an edition record listing `isbn_10` alone, in both cases the
+    //      The *ISBN* now survives too (issue #10). Two of the five captures —
+    //      Dune and Sapiens — carry no `isbn_13` at all: OL answered with an
+    //      edition record listing `isbn_10` alone, in both cases the
     //      checksum-equivalent of the ISBN-13 that was queried (0441172717 is
-    //      9780441172719; 0062316095 is 9780062316097). So Edition.Isbn13 is
-    //      null and the candidate reaches the matcher with no ISBN.
-    //
-    //      That is not cosmetic. DistanceCalculator:86-94 then takes the
-    //      `isbn_missing` branch (weight 0.1) instead of `isbn` at distance 0
-    //      (weight 10.0), and losing a 10.0-weight bucket from the denominator
-    //      is what lets the author penalty dominate. Measured through
-    //      ToBook -> ToCandidates' backfill -> BookDistance, holding the payload
-    //      fixed and varying only Isbn13:
+    //      9780441172719; 0062316095 is 9780062316097). ToEdition used to read
+    //      `isbn_13` only, so those candidates reached the matcher with no
+    //      ISBN — DistanceCalculator:86-94 took the `isbn_missing` branch
+    //      (weight 0.1) instead of `isbn` at distance 0 (weight 10.0), and
+    //      losing a 10.0-weight bucket from the denominator is what let the
+    //      author penalty dominate. Measured through ToBook -> ToCandidates'
+    //      backfill -> BookDistance, holding the payload fixed and varying
+    //      only Isbn13:
     //
     //        Foundation, authorless, isbn_13 present  0.1469   accept
     //        Foundation, authorless, isbn_13 cleared  0.2857   REJECT (gate 0.20)
     //        Foundation, named,      isbn_13 present  0.0047
     //        Foundation, named,      isbn_13 cleared  0.0179
     //
-    //      Harmless once the author name resolves; decisive when it does not.
-    //      The Isbn13-is-null expectations below therefore pin current
-    //      behaviour, not desired behaviour — deriving ISBN-13 from `isbn_10`
-    //      is a checksum, not a round trip.
+    //      ToEdition now derives the ISBN-13 from `isbn_10` when `isbn_13` is
+    //      absent, preferring the entry that matches the queried ISBN — Dune's
+    //      record lists two printings and only the second is the one that was
+    //      looked up. The expectations below assert the derived values; the
+    //      selection unit tests live in OpenLibraryEditionMapperFixture.
     //
     //   2. Where the edition JSON carries an author key, the candidate reaches
     //      the caller with a resolved author *name* (issue #7: an authorless
@@ -62,10 +61,11 @@ namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
     //      here with real payloads so a future work-level fallback has a
     //      test to flip.
     //
-    //      Sapiens is where (1) and (3) compound: no author key to resolve AND
-    //      no isbn_13, measured at 0.5082 against the 0.20 gate. The #7 fix
-    //      cannot reach it — there is no key to look a name up by — so it is
-    //      the ISBN half that would have to carry it.
+    //      Sapiens was where (1) and (3) compounded: no author key to resolve
+    //      AND no isbn_13, measured at 0.5082 against the 0.20 gate — the #7
+    //      fix cannot reach it, because there is no key to look a name up by.
+    //      With the ISBN half now carried by #10's derivation, it is back to
+    //      an ordinary authorless candidate (issue #9's remainder).
     //
     // The expectations are hardcoded rather than re-read from the JSON on
     // purpose: re-deriving them from the cassette would make the test a
@@ -109,21 +109,22 @@ namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
         }
 
         // ── the corpus, as captured ─────────────────────────────────
-        // fileName, queried ISBN, edition key, work key, Isbn13 as OL returned it
+        // fileName, queried ISBN, edition key, work key, expected Isbn13
         public static IEnumerable IdentityCases()
         {
             yield return new TestCaseData("isbn_1984_9780451524935.json", "9780451524935", "OL34854896M", "OL1168083W", "9780451524935").SetName("{m}(1984)");
 
             // Dune and Sapiens are the isbn_10-only captures: OL answered with
-            // an edition carrying no `isbn_13`, so ToEdition — which reads
-            // `isbn_13` alone — yields a null Isbn13 even though the queried
-            // ISBN is present in the payload as its ISBN-10 equivalent. The
-            // expected null is current behaviour, not desired behaviour; see
-            // the measured cost in the fixture header.
-            yield return new TestCaseData("isbn_dune_9780441172719.json", "9780441172719", "OL22597282M", "OL893415W", null).SetName("{m}(dune)");
+            // an edition carrying no `isbn_13`, so the expected Isbn13 is
+            // *derived* from `isbn_10` (issue #10) rather than read from the
+            // payload. Dune is the sharp case: its record lists two printings
+            // (0441172660, 0441172717) and only the second converts to the
+            // queried ISBN — a first-entry fallback would assert 9780441172665
+            // here and fail.
+            yield return new TestCaseData("isbn_dune_9780441172719.json", "9780441172719", "OL22597282M", "OL893415W", "9780441172719").SetName("{m}(dune)");
             yield return new TestCaseData("isbn_foundation_9780553293357.json", "9780553293357", "OL7825249M", "OL46125W", "9780553293357").SetName("{m}(foundation)");
             yield return new TestCaseData("isbn_hobbit_9780261103573.json", "9780261103573", "OL10236417M", "OL27513W", "9780261103573").SetName("{m}(fellowship)");
-            yield return new TestCaseData("isbn_sapiens_9780062316097.json", "9780062316097", "OL27000666M", "OL17075811W", null).SetName("{m}(sapiens)");
+            yield return new TestCaseData("isbn_sapiens_9780062316097.json", "9780062316097", "OL27000666M", "OL17075811W", "9780062316097").SetName("{m}(sapiens)");
         }
 
         [TestCaseSource(nameof(IdentityCases))]

--- a/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryIsbnSearchCassetteFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/OpenLibrary/OpenLibraryIsbnSearchCassetteFixture.cs
@@ -1,0 +1,224 @@
+using System.Collections;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.MetadataSource.OpenLibrary;
+using NzbDrone.Core.MetadataSource.OpenLibrary.Resources;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Test.MetadataSource.OpenLibrary.Fixtures;
+
+namespace NzbDrone.Core.Test.MetadataSource.OpenLibrary
+{
+    // SearchByIsbn against the real /isbn/{isbn}.json payloads committed under
+    // Files/OpenLibrary/, driven through the proxy rather than the mappers.
+    // The cassette corpus already proves these payloads *deserialize and map*
+    // (OpenLibraryCassetteFixture); this fixture pins what the ISBN route
+    // promises on top of that, against JSON OL actually served:
+    //
+    //   1. Edition identity survives. /isbn/ resolves one ISBN to one edition,
+    //      and the candidate carries that edition's own key — the property
+    //      ReidentifyService's 0.95-confidence mapping rests on, and the reason
+    //      this route exists instead of a search.json query (which returns
+    //      work-level docs and whichever ISBN happens to be listed first).
+    //      See the review on PR #4.
+    //
+    //      The *ISBN* does not always survive with it, which is the more
+    //      interesting half. ToEdition reads `isbn_13` only, and two of the five
+    //      captures — Dune and Sapiens — carry no `isbn_13` at all: OL answered
+    //      with an edition record listing `isbn_10` alone, in both cases the
+    //      checksum-equivalent of the ISBN-13 that was queried (0441172717 is
+    //      9780441172719; 0062316095 is 9780062316097). So Edition.Isbn13 is
+    //      null and the candidate reaches the matcher with no ISBN.
+    //
+    //      That is not cosmetic. DistanceCalculator:86-94 then takes the
+    //      `isbn_missing` branch (weight 0.1) instead of `isbn` at distance 0
+    //      (weight 10.0), and losing a 10.0-weight bucket from the denominator
+    //      is what lets the author penalty dominate. Measured through
+    //      ToBook -> ToCandidates' backfill -> BookDistance, holding the payload
+    //      fixed and varying only Isbn13:
+    //
+    //        Foundation, authorless, isbn_13 present  0.1469   accept
+    //        Foundation, authorless, isbn_13 cleared  0.2857   REJECT (gate 0.20)
+    //        Foundation, named,      isbn_13 present  0.0047
+    //        Foundation, named,      isbn_13 cleared  0.0179
+    //
+    //      Harmless once the author name resolves; decisive when it does not.
+    //      The Isbn13-is-null expectations below therefore pin current
+    //      behaviour, not desired behaviour — deriving ISBN-13 from `isbn_10`
+    //      is a checksum, not a round trip.
+    //
+    //   2. Where the edition JSON carries an author key, the candidate reaches
+    //      the caller with a resolved author *name* (issue #7: an authorless
+    //      candidate burns 0.1875 of the 0.20 distance budget before anything
+    //      else is scored).
+    //
+    //   3. Where it does not — and two of the five captured payloads don't,
+    //      because OL frequently hangs authors on the work rather than the
+    //      edition — the candidate is authorless and no author lookup is
+    //      attempted. That is the documented boundary of the #7 fix, pinned
+    //      here with real payloads so a future work-level fallback has a
+    //      test to flip.
+    //
+    //      Sapiens is where (1) and (3) compound: no author key to resolve AND
+    //      no isbn_13, measured at 0.5082 against the 0.20 gate. The #7 fix
+    //      cannot reach it — there is no key to look a name up by — so it is
+    //      the ISBN half that would have to carry it.
+    //
+    // The expectations are hardcoded rather than re-read from the JSON on
+    // purpose: re-deriving them from the cassette would make the test a
+    // tautology. If a re-captured cassette changes shape, the table is the
+    // thing to update, consciously.
+    [TestFixture]
+    public class OpenLibraryIsbnSearchCassetteFixture : CoreTest<OpenLibraryProxy>
+    {
+        private int _authorCalls;
+
+        [SetUp]
+        public void Setup()
+        {
+            _authorCalls = 0;
+
+            // The request builder is pure URL construction — use the real one so
+            // the URLs the proxy asks for are the URLs under test.
+            Mocker.SetConstant<IOpenLibraryRequestBuilder>(new OpenLibraryRequestBuilder());
+
+            Mocker.GetMock<IHttpClient>()
+                .Setup(c => c.Get<OpenLibraryEditionResource>(It.IsAny<HttpRequest>()))
+                .Returns((HttpRequest r) => new HttpResponse<OpenLibraryEditionResource>(
+                    Response(r, OpenLibraryFixtureLoader.LoadJson(CassetteForEditionUrl(r.Url.ToString())), HttpStatusCode.OK)));
+
+            // Author lookups are served from the real author cassettes, keyed
+            // off the requested OLID. A key we have no cassette for is a 404 —
+            // not a 5xx, which would drag the proxy's 2s/4s/8s retry backoff
+            // into the test run.
+            Mocker.GetMock<IHttpClient>()
+                .Setup(c => c.Get<OpenLibraryAuthorResource>(It.IsAny<HttpRequest>()))
+                .Returns((HttpRequest r) =>
+                {
+                    _authorCalls++;
+
+                    var cassette = CassetteForAuthorUrl(r.Url.ToString());
+
+                    return cassette == null
+                        ? new HttpResponse<OpenLibraryAuthorResource>(Response(r, null, HttpStatusCode.NotFound))
+                        : new HttpResponse<OpenLibraryAuthorResource>(Response(r, OpenLibraryFixtureLoader.LoadJson(cassette), HttpStatusCode.OK));
+                });
+        }
+
+        // ── the corpus, as captured ─────────────────────────────────
+        // fileName, queried ISBN, edition key, work key, Isbn13 as OL returned it
+        public static IEnumerable IdentityCases()
+        {
+            yield return new TestCaseData("isbn_1984_9780451524935.json", "9780451524935", "OL34854896M", "OL1168083W", "9780451524935").SetName("{m}(1984)");
+
+            // Dune and Sapiens are the isbn_10-only captures: OL answered with
+            // an edition carrying no `isbn_13`, so ToEdition — which reads
+            // `isbn_13` alone — yields a null Isbn13 even though the queried
+            // ISBN is present in the payload as its ISBN-10 equivalent. The
+            // expected null is current behaviour, not desired behaviour; see
+            // the measured cost in the fixture header.
+            yield return new TestCaseData("isbn_dune_9780441172719.json", "9780441172719", "OL22597282M", "OL893415W", null).SetName("{m}(dune)");
+            yield return new TestCaseData("isbn_foundation_9780553293357.json", "9780553293357", "OL7825249M", "OL46125W", "9780553293357").SetName("{m}(foundation)");
+            yield return new TestCaseData("isbn_hobbit_9780261103573.json", "9780261103573", "OL10236417M", "OL27513W", "9780261103573").SetName("{m}(fellowship)");
+            yield return new TestCaseData("isbn_sapiens_9780062316097.json", "9780062316097", "OL27000666M", "OL17075811W", null).SetName("{m}(sapiens)");
+        }
+
+        [TestCaseSource(nameof(IdentityCases))]
+        public void Isbn_cassette_should_map_to_the_edition_ol_resolved(string fileName, string isbn, string editionKey, string workKey, string isbn13)
+        {
+            var books = Subject.SearchByIsbn(isbn);
+
+            books.Should().HaveCount(1, "/isbn/ resolves one ISBN to one edition");
+
+            var book = books[0];
+            book.ForeignEditionId.Should().Be(editionKey);
+            book.ForeignBookId.Should().Be(workKey, "the slim book wraps the edition's work");
+
+            var edition = book.Editions.Value.Should().ContainSingle().Subject;
+            edition.ForeignEditionId.Should().Be(editionKey);
+            edition.Isbn13.Should().Be(isbn13);
+        }
+
+        public static IEnumerable AuthorBearingCases()
+        {
+            yield return new TestCaseData("9780441172719", "OL79034A", "Frank Herbert").SetName("{m}(dune)");
+            yield return new TestCaseData("9780553293357", "OL34221A", "Isaac Asimov").SetName("{m}(foundation)");
+            yield return new TestCaseData("9780261103573", "OL26320A", "J.R.R. Tolkien").SetName("{m}(fellowship)");
+        }
+
+        [TestCaseSource(nameof(AuthorBearingCases))]
+        public void Isbn_cassette_with_an_author_key_should_reach_the_caller_named(string isbn, string authorId, string authorName)
+        {
+            var books = Subject.SearchByIsbn(isbn);
+
+            var metadata = books[0].AuthorMetadata.Value;
+            metadata.ForeignAuthorId.Should().Be(authorId);
+            metadata.Name.Should().Be(authorName, "an authorless candidate spends 0.1875 of the 0.20 distance budget on nothing");
+
+            books[0].Author.Value.CleanName.Should().NotBeNullOrEmpty("DistanceCalculator compares clean names");
+            _authorCalls.Should().Be(1);
+        }
+
+        // 1984 and Sapiens really came back from OL with no edition-level
+        // `authors` — the author hangs on the work. The #7 fix deliberately
+        // does not chase that (it would be a second lookup per candidate for
+        // a case the edition data can't see), so these candidates stay
+        // authorless and score accordingly. If a work-level fallback ever
+        // lands, these are the cases that should start carrying a name.
+        [TestCase("9780451524935", TestName = "{m}(1984)")]
+        [TestCase("9780062316097", TestName = "{m}(sapiens)")]
+        public void Isbn_cassette_without_edition_level_authors_should_skip_the_author_lookup(string isbn)
+        {
+            var books = Subject.SearchByIsbn(isbn);
+
+            books.Should().HaveCount(1, "no author is still a usable candidate");
+            books[0].AuthorMetadata.Should().BeNull("OL's edition JSON carried no author key to resolve");
+            _authorCalls.Should().Be(0, "there is nothing to look up");
+        }
+
+        // ── helpers ─────────────────────────────────────────────────
+        private static HttpResponse Response(HttpRequest request, string json, HttpStatusCode status)
+        {
+            return new HttpResponse(request, new HttpHeader(), Encoding.UTF8.GetBytes(json ?? string.Empty), status);
+        }
+
+        private static string CassetteForEditionUrl(string url)
+        {
+            foreach (TestCaseData c in IdentityCases())
+            {
+                var fileName = (string)c.Arguments[0];
+                var isbn = (string)c.Arguments[1];
+
+                if (url.Contains($"isbn/{isbn}.json"))
+                {
+                    return fileName;
+                }
+            }
+
+            throw new AssertionException($"Unexpected edition request: {url}");
+        }
+
+        private static string CassetteForAuthorUrl(string url)
+        {
+            if (url.Contains("authors/OL79034A.json"))
+            {
+                return "author_frank_herbert.json";
+            }
+
+            if (url.Contains("authors/OL34221A.json"))
+            {
+                return "author_asimov.json";
+            }
+
+            if (url.Contains("authors/OL26320A.json"))
+            {
+                return "author_tolkien.json";
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/IsbnUtils.cs
+++ b/src/NzbDrone.Core/Books/IsbnUtils.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Core.Books
+{
+    // ISBN normalisation and ISBN-10 -> ISBN-13 conversion, shared by the
+    // OpenLibrary edition mapper (which derives an edition's ISBN-13 when OL
+    // lists only an isbn_10 — issue #10) and by DistanceCalculator (which must
+    // compare a file's ISBN against that edition's ISBN in the *same* space —
+    // a file tagged with an ISBN-10 would otherwise never match a derived or
+    // listed ISBN-13, scoring the full 10.0-weight mismatch instead of the
+    // benign 0.1 isbn_missing bucket). The checksum maths also lived, in part,
+    // as private helpers in both places and in EbookTagService; this is the
+    // single home the PR #13 review asked for.
+    public static class IsbnUtils
+    {
+        // Bare comparison form: digits plus the ISBN-10 'X' check digit,
+        // upper-cased, hyphens and spaces removed. Null for anything with no
+        // usable characters.
+        public static string NormalizeIsbn(string isbn)
+        {
+            if (isbn.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            var chars = isbn.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray();
+            return chars.Length == 0 ? null : new string(chars).ToUpperInvariant();
+        }
+
+        // Everything the matcher compares is ISBN-13: listed isbn_13 entries
+        // are 13 digits, derived ones by construction, and a file tag can be
+        // either. Convert an ISBN-10 up, pass a normalised ISBN-13 through,
+        // and return null for anything that is neither a valid ISBN-10 nor a
+        // 13-digit value. Deriving ISBN-13 from ISBN-10 is a checksum, not a
+        // round trip, so it is safe to do on both sides of the comparison.
+        public static string ToIsbn13(string isbn)
+        {
+            var normalized = NormalizeIsbn(isbn);
+            if (normalized == null)
+            {
+                return null;
+            }
+
+            if (normalized.Length == 13)
+            {
+                return normalized;
+            }
+
+            return Isbn10ToIsbn13(normalized);
+        }
+
+        // Prefix 978, drop the ISBN-10 check digit, recompute mod-10. The
+        // entry's own checksum is validated first, so a corrupt value is
+        // skipped rather than laundered into a plausible-looking ISBN-13.
+        public static string Isbn10ToIsbn13(string isbn10)
+        {
+            var normalized = NormalizeIsbn(isbn10);
+            if (normalized == null || normalized.Length != 10 || !IsValidIsbn10(normalized))
+            {
+                return null;
+            }
+
+            var stem = "978" + normalized.Substring(0, 9);
+            var sum = 0;
+            for (var i = 0; i < 12; i++)
+            {
+                sum += (stem[i] - '0') * (i % 2 == 0 ? 1 : 3);
+            }
+
+            return stem + (char)('0' + ((10 - (sum % 10)) % 10));
+        }
+
+        // Weights 10..2 over the first nine digits, check digit weight 1, with
+        // 'X' standing for 10 in the final position only. Expects a normalised
+        // (upper-cased, punctuation-free) string.
+        public static bool IsValidIsbn10(string isbn)
+        {
+            if (isbn == null || isbn.Length != 10)
+            {
+                return false;
+            }
+
+            var sum = 0;
+            for (var i = 0; i < 9; i++)
+            {
+                if (!char.IsDigit(isbn[i]))
+                {
+                    return false;
+                }
+
+                sum += (isbn[i] - '0') * (10 - i);
+            }
+
+            if (isbn[9] != 'X' && !char.IsDigit(isbn[9]))
+            {
+                return false;
+            }
+
+            var check = isbn[9] == 'X' ? 10 : isbn[9] - '0';
+            return (sum + check) % 11 == 0;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Identification/DistanceCalculator.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Identification/DistanceCalculator.cs
@@ -82,16 +82,27 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Identification
             dist.AddString("book", fileTitles, titleOptions);
             Logger.Trace("book: '{0}' vs '{1}'; {2}", fileTitles.ConcatToString("' or '"), titleOptions.ConcatToString("' or '"), dist.NormalizedDistance());
 
-            var isbn = localTracks.MostCommon(x => x.FileTrackInfo.Isbn);
-            if (isbn.IsNotNullOrWhiteSpace() && edition.Isbn13.IsNotNullOrWhiteSpace())
+            // Both sides are compared in ISBN-13 space. The file tag is
+            // whatever the ebook carried — StripIsbn keeps a valid ISBN-10 at
+            // ten digits — and the edition's Isbn13 may itself have been
+            // derived from an isbn_10 record (#10). Without converting the file
+            // side, an ISBN-10-tagged file would read as a full mismatch
+            // against the very edition it was looked up by: the 10.0-weight
+            // isbn bucket at distance 1 instead of the 0.1 isbn_missing bucket
+            // it used to fall into — a regression the ISBN-13 derivation would
+            // otherwise introduce for exactly the Calibre/older files it aims
+            // to help. (#13 review, Finding 1.)
+            var isbn = IsbnUtils.ToIsbn13(localTracks.MostCommon(x => x.FileTrackInfo.Isbn));
+            var editionIsbn = IsbnUtils.ToIsbn13(edition.Isbn13);
+            if (isbn.IsNotNullOrWhiteSpace() && editionIsbn.IsNotNullOrWhiteSpace())
             {
-                dist.AddBool("isbn", isbn != edition.Isbn13);
-                Logger.Trace("isbn: '{0}' vs '{1}'; {2}", isbn, edition.Isbn13, dist.NormalizedDistance());
+                dist.AddBool("isbn", isbn != editionIsbn);
+                Logger.Trace("isbn: '{0}' vs '{1}'; {2}", isbn, editionIsbn, dist.NormalizedDistance());
             }
-            else if (isbn.IsNullOrWhiteSpace() != edition.Isbn13.IsNullOrWhiteSpace())
+            else if (isbn.IsNullOrWhiteSpace() != editionIsbn.IsNullOrWhiteSpace())
             {
                 dist.AddBool("isbn_missing", true);
-                Logger.Trace("isbn: '{0}' vs '{1}'; {2}", isbn, edition.Isbn13, dist.NormalizedDistance());
+                Logger.Trace("isbn: '{0}' vs '{1}'; {2}", isbn, editionIsbn, dist.NormalizedDistance());
             }
 
             var asin = localTracks.MostCommon(x => x.FileTrackInfo.Asin);

--- a/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryEditionMapper.cs
+++ b/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryEditionMapper.cs
@@ -8,10 +8,17 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
 {
     internal static class OpenLibraryEditionMapper
     {
+        // Overload kept for method-group use (OpenLibraryWorkMapper maps a
+        // work's edition list with no queried ISBN in play).
         public static Edition ToEdition(OpenLibraryEditionResource resource)
         {
+            return ToEdition(resource, null);
+        }
+
+        public static Edition ToEdition(OpenLibraryEditionResource resource, string queriedIsbn)
+        {
             var olKey = ExtractKey(resource.Key);
-            var isbn13 = resource.Isbn13?.FirstOrDefault();
+            var isbn13 = SelectIsbn13(resource, queriedIsbn);
             var asin = resource.Identifiers?.Amazon?.FirstOrDefault();
             var format = NormalizeFormat(resource.PhysicalFormat);
 
@@ -23,7 +30,10 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
             //      majority of Sparknotes / Pottermore editions whose JSON
             //      omits `covers`. `?default=false` (set in
             //      OpenLibraryCoverUrls) makes missing covers 404 so the
-            //      MediaCoverProxy 404-quiet path takes over.
+            //      MediaCoverProxy 404-quiet path takes over. A *derived*
+            //      ISBN-13 (isbn_10-only edition, see SelectIsbn13) works
+            //      here too: OL's cover index resolves checksum-equivalents,
+            //      verified live for both isbn_10-only captures (2026-08-05).
             //   3. olid-keyed — final fallback for editions that have no
             //      ISBN either; cheap to keep, harmless when it 404s.
             // When none of the three actually produces an image, the
@@ -59,6 +69,122 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
             };
         }
 
+        // Issue #10: two of the five captured /isbn/ payloads carry no
+        // `isbn_13` at all — OL answered with `isbn_10` only, in both cases
+        // the checksum-equivalent of the ISBN-13 that was queried. Reading
+        // `isbn_13` alone sent those candidates to the matcher with no ISBN,
+        // which drops the 10.0-weight isbn bucket from DistanceCalculator's
+        // denominator and lets the 3.0-weight author penalty dominate the
+        // normalised score (0.2857 against the 0.20 gate, measured in PR #4).
+        // Deriving the ISBN-13 from `isbn_10` is a checksum, not a round trip.
+        //
+        // Which entry matters. Dune's edition record lists two ISBN-10s —
+        // different printings on one record — and only the second is the ISBN
+        // that was queried. Blindly taking the first would attach a
+        // *different* ISBN-13 than the one the caller looked up, which is
+        // worse than none: a present-and-mismatched ISBN scores the full
+        // 10.0-weight bucket at distance 1. So the queried ISBN, when the
+        // caller knows it, wins over list order.
+        private static string SelectIsbn13(OpenLibraryEditionResource resource, string queriedIsbn)
+        {
+            var queried = NormalizeQueriedIsbn(queriedIsbn);
+
+            if (resource.Isbn13 != null && resource.Isbn13.Count > 0)
+            {
+                var preferred = queried != null
+                    ? resource.Isbn13.FirstOrDefault(i => NormalizeIsbn(i) == queried)
+                    : null;
+
+                return preferred ?? resource.Isbn13.First();
+            }
+
+            var derived = resource.Isbn10?
+                .Select(Isbn10ToIsbn13)
+                .Where(i => i != null)
+                .ToList();
+
+            if (derived == null || derived.Count == 0)
+            {
+                return null;
+            }
+
+            return derived.FirstOrDefault(i => i == queried) ?? derived.First();
+        }
+
+        // The queried ISBN can arrive in either format — ReidentifyService
+        // passes whatever the file's tags carry, and older or Calibre-tagged
+        // files commonly hold an ISBN-10. Candidates are compared in ISBN-13
+        // space (listed `isbn_13` entries are 13 digits; derived ones by
+        // construction), so a 10-digit query is converted before comparison.
+        // Without this it could never match, and the preference would fall
+        // back to list order without anyone noticing.
+        private static string NormalizeQueriedIsbn(string queriedIsbn)
+        {
+            var normalized = NormalizeIsbn(queriedIsbn);
+            if (normalized == null || normalized.Length != 10)
+            {
+                return normalized;
+            }
+
+            return Isbn10ToIsbn13(normalized) ?? normalized;
+        }
+
+        // Prefix 978, drop the ISBN-10 check digit, recompute mod-10. The
+        // entry's own checksum is validated first, so a corrupt value is
+        // skipped rather than laundered into a plausible-looking ISBN-13.
+        private static string Isbn10ToIsbn13(string isbn10)
+        {
+            var normalized = NormalizeIsbn(isbn10);
+            if (normalized == null || normalized.Length != 10 || !IsValidIsbn10(normalized))
+            {
+                return null;
+            }
+
+            var stem = "978" + normalized.Substring(0, 9);
+            var sum = 0;
+            for (var i = 0; i < 12; i++)
+            {
+                sum += (stem[i] - '0') * (i % 2 == 0 ? 1 : 3);
+            }
+
+            return stem + (char)('0' + ((10 - (sum % 10)) % 10));
+        }
+
+        private static bool IsValidIsbn10(string isbn)
+        {
+            var sum = 0;
+            for (var i = 0; i < 9; i++)
+            {
+                if (!char.IsDigit(isbn[i]))
+                {
+                    return false;
+                }
+
+                sum += (isbn[i] - '0') * (10 - i);
+            }
+
+            var check = isbn[9] == 'X' ? 10 : isbn[9] - '0';
+            if (isbn[9] != 'X' && !char.IsDigit(isbn[9]))
+            {
+                return false;
+            }
+
+            return (sum + check) % 11 == 0;
+        }
+
+        // Hyphens and casing vary between what callers pass and what OL
+        // stores; compare on bare digits (plus the ISBN-10 X check digit).
+        private static string NormalizeIsbn(string isbn)
+        {
+            if (isbn.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            var chars = isbn.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray();
+            return chars.Length == 0 ? null : new string(chars).ToUpperInvariant();
+        }
+
         // OL's Languages list carries entries like {"key": "/languages/eng"}.
         // Extract the 3-letter ISO 639-2 code from the last segment of the
         // first entry. Cycle 2 of the Le Guin completeness loop: Edition
@@ -80,7 +206,7 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
             return slash >= 0 ? key.Substring(slash + 1) : key;
         }
 
-        public static Book ToBook(OpenLibraryEditionResource resource)
+        public static Book ToBook(OpenLibraryEditionResource resource, string queriedIsbn = null)
         {
             // When an external ID lookup (ISBN, ASIN, edition OLID) hits OL,
             // we only know the edition. Reconstruct a slim book wrapper so
@@ -88,7 +214,7 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
             var workKey = resource.Works?.FirstOrDefault()?.Key;
             var foreignBookId = workKey.IsNotNullOrWhiteSpace() ? ExtractKey(workKey) : ExtractKey(resource.Key);
 
-            var edition = ToEdition(resource);
+            var edition = ToEdition(resource, queriedIsbn);
 
             var book = new Book
             {

--- a/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryEditionMapper.cs
+++ b/src/NzbDrone.Core/MetadataSource/OpenLibrary/Mappers/OpenLibraryEditionMapper.cs
@@ -85,21 +85,37 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
         // worse than none: a present-and-mismatched ISBN scores the full
         // 10.0-weight bucket at distance 1. So the queried ISBN, when the
         // caller knows it, wins over list order.
+        //
+        // Which entry can be chosen at all. The queried ISBN, when the caller
+        // knows it, disambiguates. Without it — the work-list mapping path,
+        // where ToEdition is a method group with no ISBN in play — a record
+        // carrying several printings has nothing to pick by, and committing to
+        // an arbitrary one fabricates an ISBN-13 the file may then mismatch at
+        // the full 10.0 weight (worse than the 0.1 isbn_missing that null
+        // yields). So a lone derivable ISBN-10 is taken, but several with no
+        // query stay null. (#13 review, Finding 2.)
         private static string SelectIsbn13(OpenLibraryEditionResource resource, string queriedIsbn)
         {
-            var queried = NormalizeQueriedIsbn(queriedIsbn);
+            // The queried ISBN can arrive in either format — ReidentifyService
+            // passes whatever the file's tags carry, and older or Calibre-
+            // tagged files commonly hold an ISBN-10. Compare in ISBN-13 space.
+            var queried = IsbnUtils.ToIsbn13(queriedIsbn);
 
             if (resource.Isbn13 != null && resource.Isbn13.Count > 0)
             {
                 var preferred = queried != null
-                    ? resource.Isbn13.FirstOrDefault(i => NormalizeIsbn(i) == queried)
+                    ? resource.Isbn13.FirstOrDefault(i => IsbnUtils.NormalizeIsbn(i) == queried)
                     : null;
 
+                // Several listed isbn_13 with no query is the same ambiguity as
+                // the derived branch below, but each is a real ISBN-13 that OL
+                // attached to the record rather than one this code invented, and
+                // this first-wins was the behaviour before #13 — left as is.
                 return preferred ?? resource.Isbn13.First();
             }
 
             var derived = resource.Isbn10?
-                .Select(Isbn10ToIsbn13)
+                .Select(IsbnUtils.Isbn10ToIsbn13)
                 .Where(i => i != null)
                 .ToList();
 
@@ -108,81 +124,12 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary.Mappers
                 return null;
             }
 
-            return derived.FirstOrDefault(i => i == queried) ?? derived.First();
-        }
-
-        // The queried ISBN can arrive in either format — ReidentifyService
-        // passes whatever the file's tags carry, and older or Calibre-tagged
-        // files commonly hold an ISBN-10. Candidates are compared in ISBN-13
-        // space (listed `isbn_13` entries are 13 digits; derived ones by
-        // construction), so a 10-digit query is converted before comparison.
-        // Without this it could never match, and the preference would fall
-        // back to list order without anyone noticing.
-        private static string NormalizeQueriedIsbn(string queriedIsbn)
-        {
-            var normalized = NormalizeIsbn(queriedIsbn);
-            if (normalized == null || normalized.Length != 10)
+            if (queried != null)
             {
-                return normalized;
+                return derived.FirstOrDefault(i => i == queried) ?? derived.First();
             }
 
-            return Isbn10ToIsbn13(normalized) ?? normalized;
-        }
-
-        // Prefix 978, drop the ISBN-10 check digit, recompute mod-10. The
-        // entry's own checksum is validated first, so a corrupt value is
-        // skipped rather than laundered into a plausible-looking ISBN-13.
-        private static string Isbn10ToIsbn13(string isbn10)
-        {
-            var normalized = NormalizeIsbn(isbn10);
-            if (normalized == null || normalized.Length != 10 || !IsValidIsbn10(normalized))
-            {
-                return null;
-            }
-
-            var stem = "978" + normalized.Substring(0, 9);
-            var sum = 0;
-            for (var i = 0; i < 12; i++)
-            {
-                sum += (stem[i] - '0') * (i % 2 == 0 ? 1 : 3);
-            }
-
-            return stem + (char)('0' + ((10 - (sum % 10)) % 10));
-        }
-
-        private static bool IsValidIsbn10(string isbn)
-        {
-            var sum = 0;
-            for (var i = 0; i < 9; i++)
-            {
-                if (!char.IsDigit(isbn[i]))
-                {
-                    return false;
-                }
-
-                sum += (isbn[i] - '0') * (10 - i);
-            }
-
-            var check = isbn[9] == 'X' ? 10 : isbn[9] - '0';
-            if (isbn[9] != 'X' && !char.IsDigit(isbn[9]))
-            {
-                return false;
-            }
-
-            return (sum + check) % 11 == 0;
-        }
-
-        // Hyphens and casing vary between what callers pass and what OL
-        // stores; compare on bare digits (plus the ISBN-10 X check digit).
-        private static string NormalizeIsbn(string isbn)
-        {
-            if (isbn.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            var chars = isbn.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray();
-            return chars.Length == 0 ? null : new string(chars).ToUpperInvariant();
+            return derived.Count == 1 ? derived[0] : null;
         }
 
         // OL's Languages list carries entries like {"key": "/languages/eng"}.

--- a/src/NzbDrone.Core/MetadataSource/OpenLibrary/OpenLibraryProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/OpenLibrary/OpenLibraryProxy.cs
@@ -375,7 +375,10 @@ namespace NzbDrone.Core.MetadataSource.OpenLibrary
                     return new List<Book>();
                 }
 
-                return new List<Book> { OpenLibraryEditionMapper.ToBook(resp.Resource) };
+                // The queried ISBN travels with the mapping: when the edition
+                // record lists no isbn_13 (or several isbn_10 printings), the
+                // mapper needs it to derive/select the right one — issue #10.
+                return new List<Book> { OpenLibraryEditionMapper.ToBook(resp.Resource, isbn) };
             });
 
             return WithAuthorNames(books);


### PR DESCRIPTION
Fixes #10, as scoped there — with one deviation from the issue's fix sketch, explained below.

**Stacked on #4**: the branch sits on 44d3a12 because the fix flips the `Isbn13`-is-null expectations in that PR's cassette fixture ("update that table as part of the change rather than around it"). Until #4 merges this PR shows both commits; once it lands I'll rebase and the diff collapses to the one fix commit — say the word if you'd rather have it re-cut against main some other way.

## What it does

`ToEdition` now derives the ISBN-13 when `isbn_13` is absent: prefix 978, drop the ISBN-10 check digit, recompute mod-10. The entry's own ISBN-10 checksum is validated first, so a corrupt value is skipped rather than laundered into a plausible-looking identifier.

## The deviation: "else take the first" would have broken Dune

The issue suggests preferring the entry matching the queried ISBN "if the caller knows it, else take the first". The caller now always knows it — `SearchByIsbn` threads the queried ISBN into the mapper — because on the actual corpus the fallback is not benign. Dune's record lists two printings (`0441172660`, `0441172717`) and only the **second** converts to the queried 9780441172719; the first converts to 9780441172665. Attaching that one is worse than attaching none: a present-and-mismatched ISBN scores the full 10.0-weight bucket at distance 1, instead of `isbn_missing` at 0.1. The cassette test pins this — a first-entry implementation fails on Dune by asserting the wrong derived value.

The same preference applies to multi-entry `isbn_13` lists, where the same several-printings shape occurs. And the query is accepted in either format, compared in ISBN-13 space: `ReidentifyService.LookupFromTags` passes whatever the file's tags carry, and older or Calibre-tagged files commonly hold an ISBN-10 — without the conversion the preference could never match and would silently fall back to list order.

## Cover fallback, checked rather than assumed

A derived ISBN-13 also feeds the ISBN-keyed cover tier (`ForBookByIsbn`) — for a value OL never listed on the edition record, and editions that previously fell through to the olid tier now commit to the ISBN tier. Verified live (2026-08-05) that OL's cover index resolves checksum-equivalents: `covers.openlibrary.org/b/isbn/9780441172719-L.jpg?default=false` and `/9780062316097-L.jpg` both return the edition's actual cover (200, real bytes), as does derived-from-the-other-printing 9780441172665. No chain change needed; the behaviour is documented at the chain comment.

## Verification

- Flipped the cassette expectations first and watched exactly Dune and Sapiens fail with `Expected "978…" but found <null>` before implementing; 19/19 across both OpenLibrary fixtures after.
- Full Core suite in Debug (so `AssertNoUnexpectedLogs` runs, per #11): **2847 passed / 0 failed** — your 2836 baseline on the #4 branch plus the 11 tests this adds.
- `OpenLibraryEditionMapperFixture` (new, 11 tests): queried-over-list-order preference for both list kinds, lone-entry derivation, ISBN-10-form queries, X check digit, checksum-invalid entries skipped, nothing-usable → null, threading through `ToBook`.

## One deliberate duplication

The checksum math also exists as private helpers in `EbookTagService` (`Isbn10Checksum`/`ValidateIsbn10`/`Isbn13Checksum`). Kept the new code self-contained to hold the diff to the mapper; if you'd rather see a shared `IsbnUtils` extracted, happy to do that as a follow-up.