### PR TITLE
release: cut v1.2.2-beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ env:
   # rather than continuing the inherited Readarr 0.4.x numbering — the
   # metadata-source overhaul + UI wizard + the fork's CI/branding/CLA
   # changes are a different product even if the codebase is shared.
-  # GITHUB_RUN_NUMBER acts as the build counter (1.2.1-beta.N).
+  # GITHUB_RUN_NUMBER acts as the build counter (1.2.2-beta.N).
   # release.yml does NOT read this — it takes the version from the tag
   # name — so this line only sets what untagged dev builds call
   # themselves. Bump it when a release tag moves the line forward.
-  MAJOR_VERSION: '1.2.1-beta'
+  MAJOR_VERSION: '1.2.2-beta'
 
 jobs:
   variables:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,8 +7,8 @@
 > **Snapshot:** describes Librarr at the `1.1.0-beta` release (`main`,
 > 2026-07-30). Version-, count- and pin-bearing lines were re-verified
 > against the tree on 2026-07-30; treat anything older as suspect. The
-> shipping-version references below were bumped for the `1.2.1-beta`
-> tag on 2026-08-03, but nothing else in this file was re-verified then
+> shipping-version references below were bumped for the `1.2.2-beta`
+> tag on 2026-08-22, but nothing else in this file was re-verified then
 > — the counts and citations still date from 2026-07-30. Inherits its codebase from upstream `Readarr/Readarr` at
 > `develop` HEAD `0b79d300` ("Retirement announcement", 2025-06-27); last
 > upstream tagged release was `v0.4.18.2805` (commit `7cc02f95`,
@@ -173,7 +173,7 @@ all of Open Library to that author's bibliography.
 
 ### CI / packaging
 
-- `azure-pipelines.yml:22` — `majorVersion: '1.2.1-beta'`.
+- `azure-pipelines.yml:22` — `majorVersion: '1.2.2-beta'`.
 - `distribution/docker/Dockerfile` — self-contained multi-stage build
   (Phase 9b). Compiles backend + frontend inside the image, runs on
   `aspnet:10.0-alpine`. Build command + run shape documented in
@@ -234,7 +234,7 @@ The architecture is **forked from Sonarr** and shows it in two visible ways:
 
    The ruleset was forked from Radarr without retitling.
 
-The product currently versions itself at `1.2.1-beta`
+The product currently versions itself at `1.2.2-beta`
 (`azure-pipelines.yml:22`). The `AssemblyVersion 10.0.0.*` in
 `Directory.Build.props:77` is the historical Readarr placeholder the CI
 overwrites at build time — not the shipping version, and not bumped
@@ -915,7 +915,7 @@ Setup → Build_Backend (Linux | Mac | Windows matrix)
 
 Notable variables (`azure-pipelines.yml:6-23`):
 
-- `majorVersion: '1.2.1-beta'` — the *real* shipping version
+- `majorVersion: '1.2.2-beta'` — the *real* shipping version
   (`azure-pipelines.yml:22`).
 - `minorVersion: $[counter('minorVersion', 1)]` — auto-incremented.
 - `dotnetVersion: '10.0.302'` — .NET 10 LTS (migrated 2026-07-30).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project loosely follows [Semantic Versioning](https://semver.org/spec/v
 
 ## [Unreleased]
 
+## [1.2.2-beta] — 2026-08-22
+
 ### Added
 
 - **Librarr now stops importing when Open Library stops answering.** Since
@@ -94,6 +96,30 @@ and this project loosely follows [Semantic Versioning](https://semver.org/spec/v
   matched nothing. Aborting is no longer how you find that out, so it needs to
   be audible. A counter that gives up after N consecutive refusals is the
   fuller answer and is not done here.
+
+- **Editions carrying only an ISBN-10 now match on ISBN.** Diagnosed and
+  fixed by [@KevlarD-67](https://github.com/KevlarD-67) in
+  [#13](https://github.com/Rorqualx/Librarr/pull/13), continuing the
+  live-library ISBN work above. Open Library records many editions with an
+  `isbn_10` and no `isbn_13`. Those reached the import matcher with
+  `Edition.Isbn13` null, so identification took the `isbn_missing` branch
+  (weight `0.1`) instead of the `isbn` distance bucket (weight `10.0`) an
+  ISBN-bearing candidate is supposed to win on. The edition mapper now
+  derives the ISBN-13 an ISBN-10-only edition actually carries — the `978`
+  prefix, the first nine digits, and a recomputed mod-10 check digit.
+
+  The ISBN-10 is validated first and dropped when it fails, never converted
+  mechanically. A *bogus* derived ISBN-13 scores the full `1.0` distance at
+  weight `10.0` and is strictly worse than an absent one at `0.1`, so a
+  malformed source ISBN must forfeit the bucket rather than poison it.
+
+- **Books whose edition names no author now fall back to the work's author.**
+  [#14](https://github.com/Rorqualx/Librarr/pull/14). Some Open Library
+  editions carry no `authors` of their own and lean on the parent work for
+  them. The mapper read the author only from the edition, so those books
+  arrived authorless and scored maximum author-distance at the matcher — the
+  same failure mode as the nameless ISBN-candidate bug above, one level up.
+  The work's author is now used when the edition has none.
 
 ## [1.2.1-beta] — 2026-08-03
 
@@ -647,7 +673,8 @@ fork's code-level inventory.
 - Internal `Readarr.*` csproj rename / `NzbDrone.*` namespace
   rebrand (deliberately preserved).
 
-[Unreleased]: https://github.com/Rorqualx/Librarr/compare/v1.2.1-beta...HEAD
+[Unreleased]: https://github.com/Rorqualx/Librarr/compare/v1.2.2-beta...HEAD
+[1.2.2-beta]: https://github.com/Rorqualx/Librarr/compare/v1.2.1-beta...v1.2.2-beta
 [1.2.1-beta]: https://github.com/Rorqualx/Librarr/compare/v1.2.0-beta...v1.2.1-beta
 [1.2.0-beta]: https://github.com/Rorqualx/Librarr/compare/v1.1.0-beta...v1.2.0-beta
 [1.1.0-beta]: https://github.com/Rorqualx/Librarr/compare/v1.0.0-beta...v1.1.0-beta

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Project memory for Claude sessions working in this repo.
 continuation of the archived Readarr (Servarr-family sibling of Sonarr,
 Radarr, Lidarr). Forked from Readarr at upstream `develop` HEAD
 `0b79d300` ("Retirement announcement", 2025-06-27). Currently at
-**`1.2.1-beta`** — engineering gate cleared, see
+**`1.2.2-beta`** — engineering gate cleared, see
 [`CHANGELOG.md`](CHANGELOG.md). The previous upstream tagged release was
 `v0.4.18.2805` (commit `7cc02f95`, 2025-06-10).
 
@@ -78,7 +78,7 @@ number that is wrong is worse than no number, because it gets trusted.
   FluentMigrator (`Servarr.FluentMigrator.Runner 3.3.2.9`; **48 migrations**,
   latest `047_root_folder_audiobook_quality_profile`), dual **SQLite +
   PostgreSQL**, NLog logging, **Sentry 4.0.2**. Shipping version
-  `1.2.1-beta` (`azure-pipelines.yml:22`). `Directory.Build.props:77`
+  `1.2.2-beta` (`azure-pipelines.yml:22`). `Directory.Build.props:77`
   `AssemblyVersion 10.0.0.*` is the historical Readarr placeholder the CI
   overwrites at build time; not the shipping version.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Nightly integration](https://github.com/Rorqualx/Librarr/actions/workflows/nightly-integration.yml/badge.svg)](https://github.com/Rorqualx/Librarr/actions/workflows/nightly-integration.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE.md)
 
-> **1.2.1-beta — 2026-08-03.** Forked from the archived
+> **1.2.2-beta — 2026-08-22.** Forked from the archived
 > [Readarr/Readarr](https://github.com/Readarr/Readarr) project (last
 > upstream commit `0b79d300`, 2025-06-27). Rebuilds Readarr on top of
 > Open Library as the primary metadata source.
@@ -170,7 +170,7 @@ that would settle it.
 
 ## Status
 
-**1.2.1-beta.** The OpenLibrary metadata proxy, BookIdMapping bridge,
+**1.2.2-beta.** The OpenLibrary metadata proxy, BookIdMapping bridge,
 reidentify pipeline, first-boot migration, Library Import wizard, and
 multi-arch images are all shipped, joined in the 1.2.x-beta line by per-format
 quality profiles, a root-folder audiobook profile default, and the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,8 +3,8 @@
 ## Supported versions
 
 Librarr is in beta, and only the most recent release is patched. That
-is `1.2.1-beta` as of 2026-08-03 — earlier tags, `1.2.0-beta`,
-`1.1.0-beta` and `1.0.0-beta` included, get nothing. Check the [releases page][releases] rather than trusting
+is `1.2.2-beta` as of 2026-08-22 — earlier tags, `1.2.1-beta`,
+`1.2.0-beta`, `1.1.0-beta` and `1.0.0-beta` included, get nothing. Check the [releases page][releases] rather than trusting
 this line to have stayed current.
 
 ## Reporting a Vulnerability

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
   # Phase 9: version reset to the Librarr 1.0.0-beta.x line. Kept in sync
   # with .github/workflows/build.yml — this Azure file is deprecated and
   # will be removed once GHA is fully verified on a public CI runner.
-  majorVersion: '1.2.1-beta'
+  majorVersion: '1.2.2-beta'
   minorVersion: $[counter('minorVersion', 1)]
   readarrVersion: '$(majorVersion).$(minorVersion)'
   buildName: '$(Build.SourceBranchName).$(readarrVersion)'

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Librarr roadmap
 
-Status as of the 1.2.1-beta line. Items are roughly ordered by
+Status as of the 1.2.2-beta line. Items are roughly ordered by
 priority; nothing here is a hard commitment.
 
 ## Open work at a glance


### PR DESCRIPTION
Cuts the **1.2.2-beta** release — the 22 commits on `main` since `v1.2.1-beta` had never been tagged.

## What's in it

The CHANGELOG's `[Unreleased]` section is finalized as `## [1.2.2-beta] — 2026-08-22`, with two user-facing fixes added that had landed but were undocumented:

- **ISBN-13 derivation for `isbn_10`-only editions (#13)** — editions Open Library carries with only an `isbn_10` reached the import matcher with a null `Edition.Isbn13`, forfeiting the weight-`10.0` `isbn` bucket for the `0.1` `isbn_missing` branch. The mapper now derives the ISBN-13 (validating the ISBN-10 first, dropping invalid ones rather than converting mechanically). Verified locally: full solution builds in Debug (0 errors) and the 52 ISBN tests pass.
- **Work→author fallback for authorless editions (#14)** — editions with no `authors` of their own now resolve the author through the parent work instead of arriving authorless at the matcher.

The circuit-breaker `Added` entry and the two KevlarD import fixes were already documented.

## Version bumps

- `MAJOR_VERSION` in `.github/workflows/build.yml` (canonical — `release.yml` reads the version from the tag; this only names untagged dev builds) and the deprecated-but-kept-in-sync `azure-pipelines.yml`.
- "Current version" claims in `README`, `CLAUDE.md`, `ARCHITECTURE.md`, `SECURITY.md`, `docs/roadmap.md`, and the CHANGELOG link footer.

## Shipping

Merging this does **not** release anything. Pushing the `v1.2.2-beta` tag fires `release.yml`, which produces the multi-RID archives, Windows installers, and multi-arch Docker images, and creates a **draft** GitHub release. Publishing that draft stays a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)